### PR TITLE
Fix globaliztion error in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
 WORKDIR /app 
 EXPOSE 80
 EXPOSE 443 
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+ENV DOTNET_RUNNING_IN_CONTAINER=true
+
+RUN apk add --no-cache icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
 
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
@@ -39,9 +43,6 @@ COPY --from=build /app/out ./
 
 RUN mkdir -p /app/images
 RUN mkdir -p /app/thumbnails
-
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
-ENV DOTNET_RUNNING_IN_CONTAINER=true
 
 # ENTRYPOINT ["dotnet", "Bing.Wallpaper.dll"]
 ENTRYPOINT ["./Bing.Wallpaper"]

--- a/src/Bing.Wallpaper/Bing.Wallpaper.csproj
+++ b/src/Bing.Wallpaper/Bing.Wallpaper.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>2.1.5</Version>
+		<Version>2.1.6</Version>
 		<InvariantGlobalization>false</InvariantGlobalization>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
Logs in docker container:

```
Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
```