### PR TITLE
chore(frontend): re-enable temporarily disabled ESLint rules

### DIFF
--- a/.github/workflows/pr-completed.yml
+++ b/.github/workflows/pr-completed.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           cd frontend
           pnpm install --frozen-lockfile
+          pnpm run lint
           pnpm run build
 
       - name: Restore dependencies

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           cd frontend
           pnpm install --frozen-lockfile
+          pnpm run lint
           pnpm run build
 
       - name: Restore dependencies

--- a/docs/plans/375-chorefrontend-re-enable-temporarily-disabled-eslint-rules-after-nextjs-migration/task-plan.md
+++ b/docs/plans/375-chorefrontend-re-enable-temporarily-disabled-eslint-rules-after-nextjs-migration/task-plan.md
@@ -1,0 +1,75 @@
+# Task Plan
+
+## Issue
+- GitHub Issue: #375
+- Title: `chore(frontend): re-enable temporarily disabled ESLint rules after Next.js migration`
+
+## Goal
+Next.js 마이그레이션 중 임시 비활성화된 ESLint 규칙을 단계적으로 재활성화하고, 기능 회귀 없이 CI에서 강제되도록 구성한다.
+
+## Scope
+- `@typescript-eslint/no-explicit-any`
+- `@typescript-eslint/no-empty-object-type`
+- `react-hooks/set-state-in-effect`
+- `@next/next/no-img-element`
+- `jsx-a11y/alt-text`
+
+## Current Baseline
+- 비활성 규칙 위치: `frontend/eslint.config.mjs`
+- 현재 CI(`.github/workflows/verify-pr.yml`)에 frontend lint 단계 없음
+- 규칙별 잠정 위반 수(규칙만 임시 error로 강제 실행):
+  - `@typescript-eslint/no-explicit-any`: 3
+  - `@typescript-eslint/no-empty-object-type`: 4
+  - `react-hooks/set-state-in-effect`: 3
+  - `@next/next/no-img-element`: 4
+  - `jsx-a11y/alt-text`: 4
+
+## Execution Plan
+1. Baseline 고정
+- `frontend` 기준 `pnpm lint`, `pnpm build` 결과를 기준선으로 기록한다.
+- 이슈 범위 외 기존 경고(`no-unused-vars`, `react-hooks/exhaustive-deps`)는 이번 작업의 직접 대상이 아님을 명시한다.
+
+2. 1차 재활성화 (Type 규칙)
+- `@typescript-eslint/no-empty-object-type`, `@typescript-eslint/no-explicit-any`를 먼저 처리한다.
+- 위반 코드 수정 후 두 규칙을 `error`로 상향한다.
+- 생성 코드(`frontend/src/api/*`)는 필요 시 예외 범위를 최소화하고 사유를 문서화한다.
+
+3. 2차 재활성화 (UI/접근성)
+- `@next/next/no-img-element`, `jsx-a11y/alt-text`를 함께 처리한다.
+- 일반 이미지 렌더링은 `next/image` 사용으로 전환한다.
+- 장식용 이미지 alt 정책을 명확히 적용하고, 불가피한 예외는 라인 단위로 제한한다.
+
+4. 3차 재활성화 (Hook 상태 업데이트)
+- `react-hooks/set-state-in-effect` 위반 지점을 리팩터링한다.
+- `useMemo`, 초기화 시점 조정, 이벤트 기반 업데이트 등으로 `effect` 내부 직접 상태 업데이트를 제거한다.
+- 동작 민감도가 높은 지점은 작은 단위로 분리 적용한다.
+
+5. CI lint 강제
+- `.github/workflows/verify-pr.yml`에 frontend lint step(`pnpm lint`)을 추가한다.
+- 필요 시 `.github/workflows/pr-completed.yml`에도 동일 정책을 반영해 일관성을 유지한다.
+
+6. 회귀 검증
+- 수동 검증 경로:
+  - `/`
+  - `/collector`
+  - `/logs`
+  - 이미지 모달 열기/닫기/키보드 인터랙션
+- lint/build 성공 및 핵심 화면 동작 확인 후 마무리한다.
+
+## Done Criteria
+- 대상 규칙이 `error`로 재활성화됨 (또는 예외가 최소 범위로 문서화됨)
+- CI lint 단계에서 업데이트된 규칙 세트를 강제함
+- `/`, `/collector`, `/logs`, 이미지 모달 플로우에서 기능 회귀 없음
+
+## Risks & Mitigations
+- Risk: `next/image` 전환 시 레이아웃 변화 가능
+- Mitigation: 컴포넌트별 시각 확인 및 사이즈/우선순위 속성 명시
+
+- Risk: `set-state-in-effect` 리팩터링 과정에서 렌더 타이밍 변경
+- Mitigation: 작은 단위 적용 + 핵심 플로우 수동 검증
+
+## Deliverables
+- ESLint 규칙 재활성화 반영 (`frontend/eslint.config.mjs`)
+- 위반 코드 수정 커밋
+- CI lint 단계 반영 (`.github/workflows/verify-pr.yml`, 필요 시 `pr-completed.yml`)
+- 검증 결과 기록

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -8,11 +8,11 @@ export default defineConfig([
   {
     files: ['src/BingImageApp/**/*.{ts,tsx}', 'src/api/**/*.{ts,tsx}'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-empty-object-type': 'off',
-      'react-hooks/set-state-in-effect': 'off',
-      '@next/next/no-img-element': 'off',
-      'jsx-a11y/alt-text': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-empty-object-type': 'error',
+      'react-hooks/set-state-in-effect': 'error',
+      '@next/next/no-img-element': 'error',
+      'jsx-a11y/alt-text': 'error',
     },
   },
   globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/BingImageApp/components/FullSizeImage/FullSizeImage.tsx
+++ b/frontend/src/BingImageApp/components/FullSizeImage/FullSizeImage.tsx
@@ -82,10 +82,8 @@ export const FullSizeImage = () => {
                             'thumbnail',
                         )}
                         isRequestFullScreen={isRequestedFullScreen}
-                        imgProps={{
-                            title: fullSizeImage.title ?? '',
-                            alt: fullSizeImage?.fileName ?? '',
-                        }}
+                        title={fullSizeImage.title ?? ''}
+                        alt={fullSizeImage.title ?? fullSizeImage?.fileName ?? ''}
                         onRequestedFullscreen={handleRequestedFullScreen}
                         onLoaded={handleImageElementLoaded}
                     />

--- a/frontend/src/BingImageApp/components/Image/Image.tsx
+++ b/frontend/src/BingImageApp/components/Image/Image.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useState, useRef } from 'react';
 
 export interface ImageProps {
     imgProps?: React.ImgHTMLAttributes<HTMLImageElement>;
+    alt: string;
+    title?: string;
     imageSrc?: string;
     imageThumbnailSrc?: string;
     isRequestFullScreen?: boolean;
@@ -12,6 +14,8 @@ export interface ImageProps {
 }
 
 export const Image = ({
+    alt,
+    title,
     imageSrc,
     imageThumbnailSrc,
     isRequestFullScreen,
@@ -96,10 +100,18 @@ export const Image = ({
     }, [isRequestFullScreen]);
 
     return (
+        // This component keeps native <img> because fullscreen/intersection behavior
+        // relies on direct DOM image APIs.
+        // eslint-disable-next-line @next/next/no-img-element
         <img
             {...imgProps}
             ref={imageRef}
-            src={imgProps?.src ?? (imageLoaded ? imageSrc : imageThumbnailSrc)}
+            src={
+                imgProps?.src ??
+                (imageThumbnailSrc ? (imageLoaded ? imageSrc : imageThumbnailSrc) : imageSrc)
+            }
+            alt={alt}
+            title={title}
             className={`${imgProps?.className ?? ''} ${
                 imageSrc && imageThumbnailSrc ? 'lazy-load-image' : ''
             } ${imageLoaded ? 'loaded' : ''} ${onClick ? 'is-clickable' : ''}`}

--- a/frontend/src/BingImageApp/components/ImageCollector/ImageCollector.tsx
+++ b/frontend/src/BingImageApp/components/ImageCollector/ImageCollector.tsx
@@ -33,7 +33,7 @@ export const ImageCollector = () => {
         setHasError((_) => false);
         mutate(
             ['POST:/api/bingImages'],
-            (_: any) => {
+            () => {
                 return new ApiClient().bingImage
                     .apiv10BingImagesCollectImages({
                         bingImageServiceGetRequestModel: {

--- a/frontend/src/BingImageApp/components/ImagesContent/ImageCard.tsx
+++ b/frontend/src/BingImageApp/components/ImagesContent/ImageCard.tsx
@@ -28,10 +28,8 @@ export const ImageCard = ({ image }: ImageCardProps) => {
                         `${image.fileName}`,
                         'thumbnail',
                     )}
-                    imgProps={{
-                        title: image.title ?? image.fileName ?? '',
-                        alt: image.title ?? image.fileName ?? '',
-                    }}
+                    title={image.title ?? image.fileName ?? ''}
+                    alt={image.title ?? image.fileName ?? ''}
                 />
                 <figcaption className="card-title-over-image rounded-bottom">
                     {image.title ?? image.fileName}

--- a/frontend/src/BingImageApp/components/ImagesContent/ImagesContent.tsx
+++ b/frontend/src/BingImageApp/components/ImagesContent/ImagesContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { ImagesList, ListContainer } from './ImagesList';
 import { Content, Section } from '../Layouts';
 import { FaSync } from 'react-icons/fa';
@@ -8,21 +8,34 @@ import { ApiClient } from '../../services';
 import Loading from '../Loading';
 
 export const ImagesContent = () => {
-    const [hasMoreImages, setHasMoreImages] = useState(true);
-
     const take = 10;
 
-    const { data, error, isValidating, size, setSize } = useSWRInfinite(
+    const { data, error, isValidating, setSize } = useSWRInfinite(
         (index: number) => {
             const page = index + 1;
             return [`/api/images?page=${page}`, page];
         },
-        (_: any, page: number) =>
-            new ApiClient().images
+        (_key: string, page: number) => {
+            void _key;
+            return new ApiClient().images
                 .apiv10ImagesGetAll({ page, take })
-                .then((res) => res.data),
+                .then((res) => res.data);
+        },
         {},
     );
+
+    const hasMoreImages = useMemo(() => {
+        if (!data || data.length === 0) {
+            return true;
+        }
+
+        const latestSet = data[data.length - 1];
+        if (!latestSet) {
+            return true;
+        }
+
+        return (latestSet.currentPage ?? 0) < (latestSet.totalPages ?? 0);
+    }, [data]);
 
     const handleClickLoadMore = () => {
         if (hasMoreImages) {
@@ -33,27 +46,6 @@ export const ImagesContent = () => {
     const handleClickRefresh = () => {
         setSize((_) => 1);
     };
-
-    useEffect(() => {
-        if (data) {
-            const latestSet = data.find(
-                (_, index, arr) => index === arr.length - 1,
-            );
-
-            setHasMoreImages((prevState) => {
-                let endOfList = false;
-                if (latestSet) {
-                    endOfList = latestSet.currentPage === latestSet.totalPages;
-                }
-                const hasMore = !endOfList;
-                if (prevState !== hasMore) {
-                    return hasMore;
-                }
-
-                return prevState;
-            });
-        }
-    }, [data]);
 
     useEffect(() => {
         if (error)

--- a/frontend/src/BingImageApp/components/Layouts/Card.tsx
+++ b/frontend/src/BingImageApp/components/Layouts/Card.tsx
@@ -3,6 +3,7 @@ import { UiHelper } from '../../lib/UiHelper';
 import { Content } from './Content';
 import { CardMediaContent } from './CardMediaContent';
 import { ImageModel } from '../../models';
+import { Image as AppImage } from '../Image';
 
 interface CardMedia {
     image?: ImageModel;
@@ -31,7 +32,11 @@ export const Card = ({
             {cardImage && (
                 <div className="card-image">
                     <figure>
-                        <img src={cardImage.src} alt={cardImage.alt} />
+                        <AppImage
+                            imageSrc={cardImage.src}
+                            alt={cardImage.alt}
+                            title={cardImage.alt}
+                        />
                     </figure>
                 </div>
             )}

--- a/frontend/src/BingImageApp/components/Layouts/CardMediaContent.tsx
+++ b/frontend/src/BingImageApp/components/Layouts/CardMediaContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ImageModel } from '../../models';
+import { Image as AppImage } from '../Image';
 
 interface CardMediaContent {
     title: string;
@@ -17,7 +18,11 @@ export const CardMediaContent = ({ image, content }: CardMediaContentProps) => {
             {image && (
                 <div className="media-left">
                     <figure>
-                        <img src={image.src} alt={image.alt} />
+                        <AppImage
+                            imageSrc={image.src}
+                            alt={image.alt}
+                            title={image.alt}
+                        />
                     </figure>
                 </div>
             )}

--- a/frontend/src/BingImageApp/components/Layouts/Header.tsx
+++ b/frontend/src/BingImageApp/components/Layouts/Header.tsx
@@ -3,6 +3,7 @@ import { LinkModel } from '../../models';
 import { GenericLink } from '../GenericLink';
 import { AppOptions } from '../../constants';
 import { FaGithub } from 'react-icons/fa';
+import Image from 'next/image';
 interface HeaderProps {
     menuRoutes: LinkModel[];
 }
@@ -64,7 +65,6 @@ export const Header = ({ menuRoutes }: HeaderProps) => {
         // }
 
         window.addEventListener('resize', handleWindowResize);
-        handleWindowResize();
 
         return () => {
             // if (observer) {
@@ -104,7 +104,12 @@ export const Header = ({ menuRoutes }: HeaderProps) => {
                         classNames={['navbar-item']}
                         onClick={handleClickMenu}
                     >
-                        <img src="/bbon-icon-48.png" width="auto" height="28" />{' '}
+                        <Image
+                            src="/bbon-icon-48.png"
+                            width={28}
+                            height={28}
+                            alt="bbon icon"
+                        />{' '}
                         <span className="ml-3">{AppOptions.Title}</span>
                     </GenericLink>
                     <a

--- a/frontend/src/BingImageApp/components/LogsContent/LogsContent.tsx
+++ b/frontend/src/BingImageApp/components/LogsContent/LogsContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { Content, Section } from '../Layouts';
 import { LogFilter, FormState } from './LogFilter';
@@ -10,7 +10,6 @@ export const LogsContent = () => {
     const COLUMNS_COUNT = 3;
     const take = 10;
     const [formState, setFormState] = useState<FormState>();
-    const [hasMoreLogs, setHasMoreLogs] = useState(true);
 
     const { data, error, isValidating, size, setSize } = useSWRInfinite(
         (index: number) => {
@@ -26,16 +25,30 @@ export const LogsContent = () => {
             ];
         },
         (
-            _: any,
+            _key: string,
             page: number,
             level: string | undefined,
             keyword: string | undefined,
         ) => {
+            void _key;
             return new ApiClient().logs
                 .apiv10LogsGetAll({ page, take, level, keyword })
                 .then((res) => res.data.data);
         },
     );
+
+    const hasMoreLogs = useMemo(() => {
+        if (!data || data.length === 0) {
+            return true;
+        }
+
+        const latestSet = data[data.length - 1];
+        if (!latestSet) {
+            return true;
+        }
+
+        return (latestSet.currentPage ?? 0) < (latestSet.totalPages ?? 0);
+    }, [data]);
 
     const handleClickLoadMore = () => {
         if (hasMoreLogs) {
@@ -50,26 +63,6 @@ export const LogsContent = () => {
 
         setSize((_) => 1);
     };
-
-    useEffect(() => {
-        if (data) {
-            const latestSet = data.find(
-                (_, index, arr) => index === arr.length - 1,
-            );
-            setHasMoreLogs((prevState) => {
-                let endOfList = false;
-
-                if (latestSet) {
-                    endOfList = latestSet.currentPage === latestSet.totalPages;
-                }
-                const hasMore = !endOfList;
-                if (prevState !== hasMore) {
-                    return hasMore;
-                }
-                return prevState;
-            });
-        }
-    }, [data]);
 
     useEffect(() => {
         if (error) {

--- a/frontend/src/BingImageApp/models/ApiResponseModel.ts
+++ b/frontend/src/BingImageApp/models/ApiResponseModel.ts
@@ -3,7 +3,7 @@ export interface ApiResponseModelBase {
     message?: string;
 }
 
-export interface ApiResponseModel<TData = {}> extends ApiResponseModelBase {
+export interface ApiResponseModel<TData = unknown> extends ApiResponseModelBase {
     statusCode: number;
     message?: string;
     data?: TData;

--- a/frontend/src/BingImageApp/models/ImagesApiResponseModel.ts
+++ b/frontend/src/BingImageApp/models/ImagesApiResponseModel.ts
@@ -1,8 +1,7 @@
 import { ApiResponseModel } from './ApiResponseModel';
 import { PagedModel } from './PagedModel';
 
-export interface ImagesApiResponseModel
-    extends ApiResponseModel<PagedModel<ImageItemModel>> {}
+export type ImagesApiResponseModel = ApiResponseModel<PagedModel<ImageItemModel>>;
 
 export interface ImageItemModel {
     id: string;

--- a/frontend/src/BingImageApp/models/LogsApiResponseModel.ts
+++ b/frontend/src/BingImageApp/models/LogsApiResponseModel.ts
@@ -11,8 +11,7 @@ export interface LogModel {
     exception: string;
 }
 
-export interface LogsApiResponseModel
-    extends ApiResponseModel<PagedModel<LogModel>> {}
+export type LogsApiResponseModel = ApiResponseModel<PagedModel<LogModel>>;
 
 export interface LoadLogsRequestModel {
     page: number;

--- a/frontend/src/BingImageApp/models/PagedModel.ts
+++ b/frontend/src/BingImageApp/models/PagedModel.ts
@@ -1,4 +1,4 @@
-export interface PagedModel<TData = {}> {
+export interface PagedModel<TData = unknown> {
     currentPage: number;
     limit: number;
     totalItems: number;


### PR DESCRIPTION
## Summary
- re-enable temporarily disabled ESLint rules after Next.js migration
- fix violations for `no-explicit-any`, `no-empty-object-type`, `set-state-in-effect`, `no-img-element`, `alt-text`
- add frontend lint enforcement in CI workflows (`verify-pr`, `pr-completed`)

## Validation
- `cd frontend && pnpm lint`
- `cd frontend && pnpm build`

Closes #375
